### PR TITLE
add global var to marshal stacktrace as string array instead of multiline string

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strings"
 )
 
 // PopulateStacktrace controls whether stacktraces are captured on error creation per default or not. This is
@@ -21,32 +22,36 @@ var PrintStacktrace = true
 //
 // Pretty print:
 //
-// 	github.com/eluv-io/errors-go/stack_with_long_filename_test.go:6 createErrorWithExtraLongFilename()
-// 	github.com/eluv-io/errors-go/stack_test.go:108                  func4()
-// 	github.com/eluv-io/errors-go/stack_test.go:109                  func4()
-// 	github.com/eluv-io/errors-go/stack_test.go:104                  T.func3()
-// 	github.com/eluv-io/errors-go/stack_test.go:99                   T.func2()
-// 	github.com/eluv-io/errors-go/stack_test.go:90                   func1()
-// 	github.com/eluv-io/errors-go/stack_test.go:47                   TestStack()
-// 	testing/testing.go:909                                          tRunner()
-// 	runtime/asm_amd64.s:1357                                        goexit()
+//	github.com/eluv-io/errors-go/stack_with_long_filename_test.go:6 createErrorWithExtraLongFilename()
+//	github.com/eluv-io/errors-go/stack_test.go:108                  func4()
+//	github.com/eluv-io/errors-go/stack_test.go:109                  func4()
+//	github.com/eluv-io/errors-go/stack_test.go:104                  T.func3()
+//	github.com/eluv-io/errors-go/stack_test.go:99                   T.func2()
+//	github.com/eluv-io/errors-go/stack_test.go:90                   func1()
+//	github.com/eluv-io/errors-go/stack_test.go:47                   TestStack()
+//	testing/testing.go:909                                          tRunner()
+//	runtime/asm_amd64.s:1357                                        goexit()
 //
 // Regular:
 //
-// 	github.com/eluv-io/errors-go/stack_with_long_filename_test.go:6	createErrorWithExtraLongFilename()
-// 	github.com/eluv-io/errors-go/stack_test.go:108	func4()
-// 	github.com/eluv-io/errors-go/stack_test.go:109	func4()
-// 	github.com/eluv-io/errors-go/stack_test.go:104	T.func3()
-// 	github.com/eluv-io/errors-go/stack_test.go:99	T.func2()
-// 	github.com/eluv-io/errors-go/stack_test.go:90	func1()
-// 	github.com/eluv-io/errors-go/stack_test.go:47	TestStack()
-// 	testing/testing.go:909	tRunner()
-// 	runtime/asm_amd64.s:1357	goexit()
+//	github.com/eluv-io/errors-go/stack_with_long_filename_test.go:6	createErrorWithExtraLongFilename()
+//	github.com/eluv-io/errors-go/stack_test.go:108	func4()
+//	github.com/eluv-io/errors-go/stack_test.go:109	func4()
+//	github.com/eluv-io/errors-go/stack_test.go:104	T.func3()
+//	github.com/eluv-io/errors-go/stack_test.go:99	T.func2()
+//	github.com/eluv-io/errors-go/stack_test.go:90	func1()
+//	github.com/eluv-io/errors-go/stack_test.go:47	TestStack()
+//	testing/testing.go:909	tRunner()
+//	runtime/asm_amd64.s:1357	goexit()
 var PrintStacktracePretty = true
 
 // MarshalStacktrace controls whether stacktraces are marshaled to JSON or not. If enabled, an extra "stacktrace" field
 // is added to the error's JSON struct.
 var MarshalStacktrace = true
+
+// MarshalStacktraceAsArray controls whether stacktraces are marshaled to JSON as a single string blob or as JSON array
+// containing the individual lines of the stacktrace.
+var MarshalStacktraceAsArray = true
 
 // DefaultFieldOrder defines the default order of an Error's fields in its String and JSON representations.
 //
@@ -139,7 +144,11 @@ func (e *Error) marshalFields(marshalStack bool) (res []byte, err error) {
 	if marshalStack && MarshalStacktrace && !e.ignoreStack && e.hasStack() {
 		bb := new(bytes.Buffer)
 		e.printStack(bb)
-		err = kv("stacktrace", bb.String())
+		if MarshalStacktraceAsArray {
+			err = kv("stacktrace", stacktraceToArray(bb.String()))
+		} else {
+			err = kv("stacktrace", bb.String())
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -148,6 +157,20 @@ func (e *Error) marshalFields(marshalStack bool) (res []byte, err error) {
 	b.WriteByte('}')
 
 	return b.Bytes(), nil
+}
+
+func stacktraceToArray(s string) []string {
+	// trim empty lines or lines containing only whitespace
+	s = strings.Trim(s, "\n\t ")
+	if s == "" {
+		return []string{}
+	}
+
+	res := strings.Split(s, "\n")
+	for i, line := range res {
+		res[i] = strings.Trim(line, "\t\n ")
+	}
+	return res
 }
 
 // UnmarshalJSON unmarshals the given JSON text, retaining the order of fields according to the JSON structure.
@@ -171,7 +194,20 @@ func (e *Error) unmarshalFrom(f map[orderedKey]valOrMap) {
 	for _, key := range keys {
 		val := f[key].Get()
 		if key.key == "stacktrace" {
-			e.unmarshalledStacktrace = toString(val)
+			slice, ok := val.([]interface{})
+			if ok {
+				sb := strings.Builder{}
+				for _, line := range slice {
+					if sb.Len() > 0 {
+						sb.WriteString("\n")
+					}
+					sb.WriteString("\t")
+					sb.WriteString(toString(line))
+				}
+				e.unmarshalledStacktrace = sb.String()
+			} else {
+				e.unmarshalledStacktrace = toString(val)
+			}
 		} else {
 			_ = e.With(key.key, val)
 		}
@@ -391,13 +427,13 @@ var Separator = ":\n\t"
 // the error itself.
 //
 // Examples:
-//   errors.E()                                    --> error with kind set to errors.K.Other, all other fields empty
-//   errors.E("download")                   --> same as errors.E().WithOp("download")
-//   errors.E("download", errors.K.IO)      --> same as errors.E().WithOp("download").WithKind(errors.K.IO)
-//   errors.E("download", errors.K.IO, err) --> same as errors.E().WithOp("download").WithKind(errors.K.IO).WithCause(err)
-//   errors.E("download", errors.K.IO, err, "file", f, "user", usr) --> same as errors.E()...With("file", f).With("user", usr)
-//   errors.E(errors.K.NotExist, "file", f)        --> same as errors.E().WithKind(errors.K.NotExist).With("file", f)
 //
+//	errors.E()                             --> error with kind set to errors.K.Other, all other fields empty
+//	errors.E("download")                   --> same as errors.E().WithOp("download")
+//	errors.E("download", errors.K.IO)      --> same as errors.E().WithOp("download").WithKind(errors.K.IO)
+//	errors.E("download", errors.K.IO, err) --> same as errors.E().WithOp("download").WithKind(errors.K.IO).WithCause(err)
+//	errors.E("download", errors.K.IO, err, "file", f, "user", usr) --> same as errors.E()...With("file", f).With("user", usr)
+//	errors.E(errors.K.NotExist, "file", f) --> same as errors.E().WithKind(errors.K.NotExist).With("file", f)
 func E(args ...interface{}) *Error {
 	e := NoTrace(args...)
 
@@ -438,15 +474,15 @@ func NoTrace(args ...interface{}) *Error {
 // Template returns a function that creates a base error with an initial set of fields. When called, additional fields
 // can be passed that complement the error template:
 //
-//   e := errors.Template("unmarshal", K.Invalid)
-//   ...
-//   if invalid {
-//     return e("reason", "invalid format")
-//   }
-//   ...
-//   if err != nil {
-//     return e(err)
-//   }
+//	e := errors.Template("unmarshal", K.Invalid)
+//	...
+//	if invalid {
+//	  return e("reason", "invalid format")
+//	}
+//	...
+//	if err != nil {
+//	  return e(err)
+//	}
 func Template(fields ...interface{}) TemplateFn {
 	return func(f ...interface{}) *Error {
 		return E(append(fields, f...)...).dropStackFrames(1)
@@ -647,7 +683,9 @@ func Str(text string) error {
 // Error methods. Elements that are in the second argument but not present in the first are ignored.
 //
 // For example:
+//
 //	Match(errors.E("authorize", errors.Permission), err)
+//
 // tests whether err is an Error with op=authorize and kind=Permission.
 func Match(err1, err2 error) bool {
 	if err1 == nil {
@@ -756,6 +794,7 @@ func GetRootCause(err error) error {
 // generic errors created with Str(s). Empty objects or strings are ignored.
 //
 // The exact JSON structure is:
+//
 //	{
 //	  "errors": [
 //		{"op": "op1"},
@@ -784,9 +823,12 @@ func ClearStacktrace(err error) error {
 // Ignore simply ignores a potential error returned by the given function.
 //
 // Useful in defer statements where the deferred function returns an error, i.e.
-//   defer writer.Close()
+//
+//	defer writer.Close()
+//
 // can be written as
-//   defer errors.Ignore(writer.Close)
+//
+//	defer errors.Ignore(writer.Close)
 func Ignore(f func() error) {
 	if f == nil {
 		return
@@ -811,10 +853,10 @@ func Wrap(err error, args ...interface{}) *Error {
 }
 
 // FromContext creates an error from the given context and additional error arguments as passed to E(). It returns
-//  * nil if ctx.Err() returns nil
-//  * an error from the given args and kind Timeout if the ctx timed out
-//  * an error from the given args and kind Cancelled if the ctx was cancelled
-//  * an error from the given args and the cause set to ctx.Err() otherwise.
+//   - nil if ctx.Err() returns nil
+//   - an error from the given args and kind Timeout if the ctx timed out
+//   - an error from the given args and kind Cancelled if the ctx was cancelled
+//   - an error from the given args and the cause set to ctx.Err() otherwise.
 func FromContext(ctx context.Context, args ...interface{}) *Error {
 	if ctx == nil {
 		return nil

--- a/errors.go
+++ b/errors.go
@@ -523,6 +523,22 @@ func (t TemplateFn) Add(fields ...interface{}) TemplateFn {
 	}
 }
 
+// Fields returns the fields of the template, excluding "op", "kind" and "cause". This is useful in situations where
+// the same information is used for logging and in errors.
+func (t TemplateFn) Fields() []interface{} {
+	return t().fields
+}
+
+// String returns a string representation of this template.
+func (t TemplateFn) String() string {
+	return t().Error()
+}
+
+// MarshalJSON marshals this template to JSON.
+func (t TemplateFn) MarshalJSON() ([]byte, error) {
+	return t().MarshalJSON()
+}
+
 type TFn func(err error, fields ...interface{}) error
 
 // Error returns the string presentation of this Error. Fields are ordered according to DefaultFieldOrder. The

--- a/errors_pkg_test.go
+++ b/errors_pkg_test.go
@@ -1,0 +1,62 @@
+package errors
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStacktraceToArray(t *testing.T) {
+	tests := []struct {
+		stacktrace string
+		want       []string
+	}{
+		{
+			stacktrace: "",
+			want:       []string{},
+		},
+		{
+			stacktrace: "\t  \t  ",
+			want:       []string{},
+		},
+		{
+			stacktrace: "abc",
+			want:       []string{"abc"},
+		},
+		{
+			stacktrace: "\n",
+			want:       []string{},
+		},
+		{
+			stacktrace: "\t\n\t \t",
+			want:       []string{},
+		},
+		{
+			stacktrace: "a\nb\nc",
+			want:       []string{"a", "b", "c"},
+		},
+		{
+			stacktrace: "\ta\n   b   \t \n\tc\n\n\t\n",
+			want:       []string{"a", "b", "c"},
+		},
+		{
+			stacktrace: "\tgithub.com/eluv-io/errors-go/errors_pkg_test.go:123 someError()\n" +
+				"\tgithub.com/eluv-io/errors-go/errors_test.go:921     createNestedError()\n" +
+				"\tgithub.com/eluv-io/errors-go/errors_test.go:922     createNestedError()\n" +
+				"\tgithub.com/eluv-io/errors-go/errors_test.go:604     TestError_MarshalJSON()\n",
+			want: []string{
+				"github.com/eluv-io/errors-go/errors_pkg_test.go:123 someError()",
+				"github.com/eluv-io/errors-go/errors_test.go:921     createNestedError()",
+				"github.com/eluv-io/errors-go/errors_test.go:922     createNestedError()",
+				"github.com/eluv-io/errors-go/errors_test.go:604     TestError_MarshalJSON()",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.stacktrace, func(t *testing.T) {
+			res := stacktraceToArray(test.stacktrace)
+			require.Equal(t, test.want, res)
+		})
+	}
+}

--- a/errors_test.go
+++ b/errors_test.go
@@ -9,13 +9,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/eluv-io/errors-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/eluv-io/errors-go"
 )
 
 func init() {
 	errors.PrintStacktrace = false
+	errors.MarshalStacktraceAsArray = false
 }
 
 func TestE(t *testing.T) {
@@ -649,7 +651,7 @@ func TestError_MarshalJSON(t *testing.T) {
 					// original errors...
 					// require.Equal(t, e1, e2)
 
-					// therefore, make sure that at lest the string representation - without
+					// therefore, make sure that at least the string representation - without
 					// stacktrace - is equal.
 
 					require.Equal(t, e1.ErrorNoTrace(), e2.ErrorNoTrace())
@@ -936,6 +938,16 @@ func enableStacktraces() func() {
 	return func() {
 		errors.PrintStacktrace = ps
 		errors.PrintStacktracePretty = psp
+	}
+}
+
+func enableMarshalStacktraceAsArray() func() {
+	revert := enableStacktraces()
+	msa := errors.MarshalStacktraceAsArray
+	errors.MarshalStacktraceAsArray = true
+	return func() {
+		revert()
+		errors.MarshalStacktraceAsArray = msa
 	}
 }
 

--- a/errors_test.go
+++ b/errors_test.go
@@ -661,6 +661,12 @@ func TestError_MarshalJSON(t *testing.T) {
 	}
 }
 
+func TestError_MarshalJSON_StackAsArray(t *testing.T) {
+	revert := enableMarshalStacktraceAsArray()
+	defer revert()
+	TestError_MarshalJSON(t)
+}
+
 func TestTemplate(t *testing.T) {
 	for _, template := range []func(fields ...interface{}) errors.TemplateFn{errors.Template, errors.T} {
 		fn := func(cause error) error {
@@ -700,7 +706,13 @@ func TestTemplateNoTrace(t *testing.T) {
 	}
 }
 
-func TestTemplateAdd(t *testing.T) {
+func TestTemplateFn_IfNotNil(t *testing.T) {
+	e := errors.TemplateNoTrace("op1", errors.K.Invalid)
+	require.Equal(t, nil, e.IfNotNil(nil))
+	require.Equal(t, e(io.EOF), e.IfNotNil(io.EOF))
+}
+
+func TestTemplateFn_Add(t *testing.T) {
 	e := errors.Template("op", errors.K.IO, "k1", "v1")
 	e = e.Add("k1", "v1.override", "k2", "v2", errors.K.Invalid)
 	err := e("k3", "v3", io.EOF)
@@ -708,6 +720,48 @@ func TestTemplateAdd(t *testing.T) {
 	assert.Equal(t,
 		errors.E("op", "k1", "v1.override", "k2", "v2", "k3", "v3", errors.K.Invalid, io.EOF).ClearStacktrace(),
 		err.ClearStacktrace())
+}
+
+func TestTemplateFn_Fields(t *testing.T) {
+	tests := []struct {
+		e    errors.TemplateFn
+		want []interface{}
+	}{
+		{
+			errors.Template(),
+			nil,
+		},
+		{
+			errors.Template("operation 1", errors.K.Invalid, io.EOF),
+			[]interface{}{},
+		},
+		{
+			errors.Template("operation 1", errors.K.Invalid, io.EOF, "k1", "v1"),
+			[]interface{}{"k1", "v1"},
+		},
+		{
+			errors.Template("operation 1", "k1", "v1", "k2", "v2"),
+			[]interface{}{"k1", "v1", "k2", "v2"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprint(test.e()), func(t *testing.T) {
+			require.Equal(t, test.want, test.e.Fields())
+		})
+	}
+}
+
+func TestTemplateFn_String(t *testing.T) {
+	e := errors.TemplateNoTrace("op", errors.K.IO, "k1", "v1")
+	require.Equal(t, `op [op] kind [I/O error] k1 [v1]`, e.String())
+}
+
+func TestTemplateFn_MarshalJSON(t *testing.T) {
+	e := errors.TemplateNoTrace("op", errors.K.IO, "k1", "v1")
+	jsn, err := json.Marshal(e)
+	require.NoError(t, err)
+	require.Equal(t, `{"op":"op","kind":"I/O error","k1":"v1"}`, string(jsn))
 }
 
 func TestDefaultKind(t *testing.T) {

--- a/stack_example_test.go
+++ b/stack_example_test.go
@@ -29,7 +29,7 @@ func ExampleE() {
 	defer reset()
 
 	err := getConfig()
-	fmt.Println(deleteLastLine(err.Error()))
+	fmt.Println(deleteLastLines(err.Error(), "ExampleE()"))
 
 	// Output:
 	//
@@ -39,16 +39,20 @@ func ExampleE() {
 	//	github.com/eluv-io/errors-go/stack_example_test.go:20 getConfig()
 	//	github.com/eluv-io/errors-go/stack_example_test.go:22 getConfig()
 	//	github.com/eluv-io/errors-go/stack_example_test.go:31 ExampleE()
-	//	testing/run_example.go:64                             runExample()
-	//	testing/example.go:44                                 runExamples()
-	//	testing/testing.go:1505                               (*M).Run()
 }
 
-func deleteLastLine(s string) string {
+func deleteLastLines(s string, match string) string {
 	s = strings.TrimRight(s, "\n")
-	pos := strings.LastIndexByte(s, '\n')
-	if pos >= 0 {
-		return s[:pos]
+	for {
+		pos := strings.LastIndexByte(s, '\n')
+		if pos >= 0 {
+			if strings.Contains(s[pos:], match) {
+				break
+			}
+			s = s[:pos]
+		} else {
+			break
+		}
 	}
 	return s
 }


### PR DESCRIPTION
MarshalStacktraceAsArray controls whether stacktraces are marshaled to JSON as a single string blob or as JSON array containing the individual lines of the stacktrace. It is set to true per default.

Does enabling this per default possibly break client code?