### PR TITLE
copy error when clearing stack, fix default kind handling

### DIFF
--- a/errors_test.go
+++ b/errors_test.go
@@ -348,7 +348,7 @@ func TestSeparator(t *testing.T) {
 	assert.Equal(t, want, err.Error())
 }
 
-func TestGetStringField(t *testing.T) {
+func TestGetField(t *testing.T) {
 	e1 := errors.E("Test", "key", "val1")
 	e2 := errors.E("Test", e1, "key", "val2")
 
@@ -386,6 +386,44 @@ func TestGetStringField(t *testing.T) {
 	f, ok = errors.GetField(e3, "key")
 	require.False(t, ok)
 
+}
+
+func TestField(t *testing.T) {
+	e1 := errors.E("Test", "key", "val1")
+	e2 := errors.E("Test", e1, "key", 2)
+
+	f := errors.Field(nil, "key")
+	require.Nil(t, f)
+
+	f = errors.Field(io.EOF, "key")
+	require.Nil(t, f)
+
+	f = errors.Field(e1, "missing_key")
+	require.Nil(t, f)
+
+	f = errors.Field(e2, "key")
+	require.Equal(t, 2, f)
+
+	e2 = errors.E("Test", e1, "another_key", "val2")
+	f = errors.Field(e2, "key")
+	require.Equal(t, "val1", f)
+
+	e3 := errors.E("Test", e2, "yet_another_key", 3)
+	f = errors.Field(e3, "key")
+	require.Equal(t, "val1", f)
+	f = errors.Field(e3, "yet_another_key")
+	require.Equal(t, 3, f)
+
+	e2 = errors.E("Test", e1, "key", 2)
+	e3 = errors.E("Test", e2, "yet_another_key", "val3")
+	f = errors.Field(e3, "key")
+	require.Equal(t, 2, f)
+
+	fe1 := fmt.Errorf("not an elv error %s", "x")
+	e2 = errors.E("Test", fe1, "another_key", "val2")
+	e3 = errors.E("Test", e2, "yet_another_key", "val3")
+	f = errors.Field(e3, "key")
+	require.Nil(t, f)
 }
 
 func TestGetRoot(t *testing.T) {

--- a/errors_test.go
+++ b/errors_test.go
@@ -810,7 +810,7 @@ func TestDefaultKind(t *testing.T) {
 	}{
 		{"kind is other if none set", errors.K.Other, errors.E()},
 		{"kind is other if none set, even in cause", errors.K.Other, errors.E(errors.E())},
-		{"default is used if none node set", errors.K.Invalid, errors.E(errors.K.Invalid.Default())},
+		{"default is used if none set", errors.K.Invalid, errors.E(errors.K.Invalid.Default())},
 		{"default in parent is used if none set in cause", errors.K.Invalid, errors.E(errors.K.Invalid.Default(), errors.E())},
 		{"kind in cause overrides default in parent", errors.K.Timeout, errors.E(errors.K.Invalid.Default(), errors.E(errors.K.Timeout))},
 		{"kind in parent takes precedence over kind in cause", errors.K.Invalid, errors.E(errors.K.Invalid, errors.E(errors.K.NotExist))},

--- a/stack_test.go
+++ b/stack_test.go
@@ -92,10 +92,13 @@ func TestClearStacktrace(t *testing.T) {
 	err = errors.ClearStacktrace(io.EOF)
 	assert.Equal(t, io.EOF, err)
 
-	err = errors.ClearStacktrace(createNestedError())
+	nestedError := createNestedError()
+	err = errors.ClearStacktrace(nestedError)
 	fmt.Println(err)
 	s := err.Error()
 	require.NotContains(t, s, "TestClearStacktrace")
+	require.Contains(t, nestedError.Error(), err.Error())
+
 }
 
 func validateStacktrace(t *testing.T, got string) {


### PR DESCRIPTION
* `*error.ClearStacktrace()` and `ClearStacktrace(error)` now create and return a copy of the error hierarchy before clearing the stacktrace, because errors are immutable
* fix handling of `default` kinds in nested error hierarchies. Especially: default kind in cause should override default kind in parent error.